### PR TITLE
Type registry key resolver

### DIFF
--- a/Example/FearlessUtils.xcodeproj/project.pbxproj
+++ b/Example/FearlessUtils.xcodeproj/project.pbxproj
@@ -47,6 +47,7 @@
 		849E0AAC25C96C7800B33506 /* TupleNodeFactoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 849E0AAB25C96C7800B33506 /* TupleNodeFactoryTests.swift */; };
 		849E0AB025C96DD500B33506 /* FixedArrayNodeFactoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 849E0AAF25C96DD500B33506 /* FixedArrayNodeFactoryTests.swift */; };
 		849E0AB425C96EED00B33506 /* AliasNodeFactoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 849E0AB325C96EED00B33506 /* AliasNodeFactoryTests.swift */; };
+		849E0AEA25C992F800B33506 /* CaseInsensitiveResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 849E0AE925C992F800B33506 /* CaseInsensitiveResolverTests.swift */; };
 		84A0DE3124DBF49400F436A8 /* keystore-ed25519.json in Resources */ = {isa = PBXBuildFile; fileRef = 84A0DE2D24DBF3F300F436A8 /* keystore-ed25519.json */; };
 		84A0DE3224DBF49700F436A8 /* keystore-ecdsa.json in Resources */ = {isa = PBXBuildFile; fileRef = 84A0DE2F24DBF40900F436A8 /* keystore-ecdsa.json */; };
 		84CB472424DBE82C00837E11 /* KeystoreExtractorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84CB472324DBE82C00837E11 /* KeystoreExtractorTests.swift */; };
@@ -125,6 +126,7 @@
 		849E0AAB25C96C7800B33506 /* TupleNodeFactoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TupleNodeFactoryTests.swift; sourceTree = "<group>"; };
 		849E0AAF25C96DD500B33506 /* FixedArrayNodeFactoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FixedArrayNodeFactoryTests.swift; sourceTree = "<group>"; };
 		849E0AB325C96EED00B33506 /* AliasNodeFactoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AliasNodeFactoryTests.swift; sourceTree = "<group>"; };
+		849E0AE925C992F800B33506 /* CaseInsensitiveResolverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CaseInsensitiveResolverTests.swift; sourceTree = "<group>"; };
 		84A0DE2D24DBF3F300F436A8 /* keystore-ed25519.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "keystore-ed25519.json"; sourceTree = "<group>"; };
 		84A0DE2F24DBF40900F436A8 /* keystore-ecdsa.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "keystore-ecdsa.json"; sourceTree = "<group>"; };
 		84CB472024DBE7E100837E11 /* keystore-sr25519.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "keystore-sr25519.json"; sourceTree = "<group>"; };
@@ -248,6 +250,7 @@
 		8429C7FA25C432CC0086D7F6 /* Runtime */ = {
 			isa = PBXGroup;
 			children = (
+				849E0AE825C992D200B33506 /* TypeResolution */,
 				849E0A7225C9455600B33506 /* NodeFactory */,
 				841D527E25C49AD900DFA15B /* Parser */,
 				8429C7FC25C432FF0086D7F6 /* TypeRegistryTests.swift */,
@@ -329,6 +332,14 @@
 				849E0AB325C96EED00B33506 /* AliasNodeFactoryTests.swift */,
 			);
 			path = NodeFactory;
+			sourceTree = "<group>";
+		};
+		849E0AE825C992D200B33506 /* TypeResolution */ = {
+			isa = PBXGroup;
+			children = (
+				849E0AE925C992F800B33506 /* CaseInsensitiveResolverTests.swift */,
+			);
+			path = TypeResolution;
 			sourceTree = "<group>";
 		};
 		84CB471F24DBE7BD00837E11 /* Keystore */ = {
@@ -622,6 +633,7 @@
 				849E0AB425C96EED00B33506 /* AliasNodeFactoryTests.swift in Sources */,
 				84DA3B4424C8CE5A00B5E27F /* ScaleInt16Tests.swift in Sources */,
 				849E0AA025C9684800B33506 /* VectorNodeFactoryTests.swift in Sources */,
+				849E0AEA25C992F800B33506 /* CaseInsensitiveResolverTests.swift in Sources */,
 				84DA3B3E24C8CE5900B5E27F /* ScaleInt64Tests.swift in Sources */,
 				84DA3B4024C8CE5900B5E27F /* ScaleInt8Tests.swift in Sources */,
 				84DA3B4524C8CE5A00B5E27F /* ScaleUInt8Tests.swift in Sources */,

--- a/Example/FearlessUtils.xcodeproj/project.pbxproj
+++ b/Example/FearlessUtils.xcodeproj/project.pbxproj
@@ -37,6 +37,10 @@
 		8467FD2624E71A37005D486C /* IconGenerationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8467FD2524E71A37005D486C /* IconGenerationTests.swift */; };
 		8467FD2824E72CCD005D486C /* HSLColorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8467FD2724E72CCD005D486C /* HSLColorTests.swift */; };
 		849E0A2125C81DB500B33506 /* FixedArrayParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 849E0A2025C81DB500B33506 /* FixedArrayParserTests.swift */; };
+		849E0A7425C9458F00B33506 /* StructNodeFactoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 849E0A7325C9458F00B33506 /* StructNodeFactoryTests.swift */; };
+		849E0A7A25C94E3F00B33506 /* EnumMappingFactoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 849E0A7925C94E3F00B33506 /* EnumMappingFactoryTests.swift */; };
+		849E0A7E25C95C7F00B33506 /* EnumValuesFactoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 849E0A7D25C95C7F00B33506 /* EnumValuesFactoryTests.swift */; };
+		849E0A8225C95E2700B33506 /* NumericSetFactoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 849E0A8125C95E2700B33506 /* NumericSetFactoryTests.swift */; };
 		84A0DE3124DBF49400F436A8 /* keystore-ed25519.json in Resources */ = {isa = PBXBuildFile; fileRef = 84A0DE2D24DBF3F300F436A8 /* keystore-ed25519.json */; };
 		84A0DE3224DBF49700F436A8 /* keystore-ecdsa.json in Resources */ = {isa = PBXBuildFile; fileRef = 84A0DE2F24DBF40900F436A8 /* keystore-ecdsa.json */; };
 		84CB472424DBE82C00837E11 /* KeystoreExtractorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84CB472324DBE82C00837E11 /* KeystoreExtractorTests.swift */; };
@@ -105,6 +109,10 @@
 		8467FD2524E71A37005D486C /* IconGenerationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IconGenerationTests.swift; sourceTree = "<group>"; };
 		8467FD2724E72CCD005D486C /* HSLColorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HSLColorTests.swift; sourceTree = "<group>"; };
 		849E0A2025C81DB500B33506 /* FixedArrayParserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FixedArrayParserTests.swift; sourceTree = "<group>"; };
+		849E0A7325C9458F00B33506 /* StructNodeFactoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StructNodeFactoryTests.swift; sourceTree = "<group>"; };
+		849E0A7925C94E3F00B33506 /* EnumMappingFactoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EnumMappingFactoryTests.swift; sourceTree = "<group>"; };
+		849E0A7D25C95C7F00B33506 /* EnumValuesFactoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EnumValuesFactoryTests.swift; sourceTree = "<group>"; };
+		849E0A8125C95E2700B33506 /* NumericSetFactoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NumericSetFactoryTests.swift; sourceTree = "<group>"; };
 		84A0DE2D24DBF3F300F436A8 /* keystore-ed25519.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "keystore-ed25519.json"; sourceTree = "<group>"; };
 		84A0DE2F24DBF40900F436A8 /* keystore-ecdsa.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "keystore-ecdsa.json"; sourceTree = "<group>"; };
 		84CB472024DBE7E100837E11 /* keystore-sr25519.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "keystore-sr25519.json"; sourceTree = "<group>"; };
@@ -228,6 +236,7 @@
 		8429C7FA25C432CC0086D7F6 /* Runtime */ = {
 			isa = PBXGroup;
 			children = (
+				849E0A7225C9455600B33506 /* NodeFactory */,
 				841D527E25C49AD900DFA15B /* Parser */,
 				8429C7FC25C432FF0086D7F6 /* TypeRegistryTests.swift */,
 			);
@@ -291,6 +300,17 @@
 				8467FD2524E71A37005D486C /* IconGenerationTests.swift */,
 			);
 			path = Icon;
+			sourceTree = "<group>";
+		};
+		849E0A7225C9455600B33506 /* NodeFactory */ = {
+			isa = PBXGroup;
+			children = (
+				849E0A7325C9458F00B33506 /* StructNodeFactoryTests.swift */,
+				849E0A7925C94E3F00B33506 /* EnumMappingFactoryTests.swift */,
+				849E0A7D25C95C7F00B33506 /* EnumValuesFactoryTests.swift */,
+				849E0A8125C95E2700B33506 /* NumericSetFactoryTests.swift */,
+			);
+			path = NodeFactory;
 			sourceTree = "<group>";
 		};
 		84CB471F24DBE7BD00837E11 /* Keystore */ = {
@@ -586,14 +606,18 @@
 				84DA3B4024C8CE5900B5E27F /* ScaleInt8Tests.swift in Sources */,
 				84DA3B4524C8CE5A00B5E27F /* ScaleUInt8Tests.swift in Sources */,
 				84DA3B3D24C8CE5900B5E27F /* ScaleCompactIntTests.swift in Sources */,
+				849E0A7425C9458F00B33506 /* StructNodeFactoryTests.swift in Sources */,
 				849E0A2125C81DB500B33506 /* FixedArrayParserTests.swift in Sources */,
 				84DA3B4324C8CE5A00B5E27F /* ScaleStringTests.swift in Sources */,
 				84DA3B4224C8CE5A00B5E27F /* ScaleUInt64Tests.swift in Sources */,
+				849E0A7A25C94E3F00B33506 /* EnumMappingFactoryTests.swift in Sources */,
 				842D1E6A24CF800400C30A7A /* JunctionFactoryTests.swift in Sources */,
 				8429C7FD25C432FF0086D7F6 /* TypeRegistryTests.swift in Sources */,
 				841D52EA25C6DDF800DFA15B /* JSONHelpers.swift in Sources */,
+				849E0A8225C95E2700B33506 /* NumericSetFactoryTests.swift in Sources */,
 				84DA3B4124C8CE5A00B5E27F /* ScaleInt32Tests.swift in Sources */,
 				8467FD2624E71A37005D486C /* IconGenerationTests.swift in Sources */,
+				849E0A7E25C95C7F00B33506 /* EnumValuesFactoryTests.swift in Sources */,
 				842D1E2324C98CEA00C30A7A /* StorageKeyFactoryTests.swift in Sources */,
 				8467FD2824E72CCD005D486C /* HSLColorTests.swift in Sources */,
 				842D1E2724C9B63300C30A7A /* ScaleOptionTests.swift in Sources */,

--- a/Example/FearlessUtils.xcodeproj/project.pbxproj
+++ b/Example/FearlessUtils.xcodeproj/project.pbxproj
@@ -41,6 +41,12 @@
 		849E0A7A25C94E3F00B33506 /* EnumMappingFactoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 849E0A7925C94E3F00B33506 /* EnumMappingFactoryTests.swift */; };
 		849E0A7E25C95C7F00B33506 /* EnumValuesFactoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 849E0A7D25C95C7F00B33506 /* EnumValuesFactoryTests.swift */; };
 		849E0A8225C95E2700B33506 /* NumericSetFactoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 849E0A8125C95E2700B33506 /* NumericSetFactoryTests.swift */; };
+		849E0AA025C9684800B33506 /* VectorNodeFactoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 849E0A9F25C9684800B33506 /* VectorNodeFactoryTests.swift */; };
+		849E0AA425C96A6400B33506 /* OptionNodeFactoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 849E0AA325C96A6400B33506 /* OptionNodeFactoryTests.swift */; };
+		849E0AA825C96AD600B33506 /* CompactNodeFactoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 849E0AA725C96AD600B33506 /* CompactNodeFactoryTests.swift */; };
+		849E0AAC25C96C7800B33506 /* TupleNodeFactoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 849E0AAB25C96C7800B33506 /* TupleNodeFactoryTests.swift */; };
+		849E0AB025C96DD500B33506 /* FixedArrayNodeFactoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 849E0AAF25C96DD500B33506 /* FixedArrayNodeFactoryTests.swift */; };
+		849E0AB425C96EED00B33506 /* AliasNodeFactoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 849E0AB325C96EED00B33506 /* AliasNodeFactoryTests.swift */; };
 		84A0DE3124DBF49400F436A8 /* keystore-ed25519.json in Resources */ = {isa = PBXBuildFile; fileRef = 84A0DE2D24DBF3F300F436A8 /* keystore-ed25519.json */; };
 		84A0DE3224DBF49700F436A8 /* keystore-ecdsa.json in Resources */ = {isa = PBXBuildFile; fileRef = 84A0DE2F24DBF40900F436A8 /* keystore-ecdsa.json */; };
 		84CB472424DBE82C00837E11 /* KeystoreExtractorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84CB472324DBE82C00837E11 /* KeystoreExtractorTests.swift */; };
@@ -113,6 +119,12 @@
 		849E0A7925C94E3F00B33506 /* EnumMappingFactoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EnumMappingFactoryTests.swift; sourceTree = "<group>"; };
 		849E0A7D25C95C7F00B33506 /* EnumValuesFactoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EnumValuesFactoryTests.swift; sourceTree = "<group>"; };
 		849E0A8125C95E2700B33506 /* NumericSetFactoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NumericSetFactoryTests.swift; sourceTree = "<group>"; };
+		849E0A9F25C9684800B33506 /* VectorNodeFactoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VectorNodeFactoryTests.swift; sourceTree = "<group>"; };
+		849E0AA325C96A6400B33506 /* OptionNodeFactoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OptionNodeFactoryTests.swift; sourceTree = "<group>"; };
+		849E0AA725C96AD600B33506 /* CompactNodeFactoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompactNodeFactoryTests.swift; sourceTree = "<group>"; };
+		849E0AAB25C96C7800B33506 /* TupleNodeFactoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TupleNodeFactoryTests.swift; sourceTree = "<group>"; };
+		849E0AAF25C96DD500B33506 /* FixedArrayNodeFactoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FixedArrayNodeFactoryTests.swift; sourceTree = "<group>"; };
+		849E0AB325C96EED00B33506 /* AliasNodeFactoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AliasNodeFactoryTests.swift; sourceTree = "<group>"; };
 		84A0DE2D24DBF3F300F436A8 /* keystore-ed25519.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "keystore-ed25519.json"; sourceTree = "<group>"; };
 		84A0DE2F24DBF40900F436A8 /* keystore-ecdsa.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "keystore-ecdsa.json"; sourceTree = "<group>"; };
 		84CB472024DBE7E100837E11 /* keystore-sr25519.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "keystore-sr25519.json"; sourceTree = "<group>"; };
@@ -309,6 +321,12 @@
 				849E0A7925C94E3F00B33506 /* EnumMappingFactoryTests.swift */,
 				849E0A7D25C95C7F00B33506 /* EnumValuesFactoryTests.swift */,
 				849E0A8125C95E2700B33506 /* NumericSetFactoryTests.swift */,
+				849E0A9F25C9684800B33506 /* VectorNodeFactoryTests.swift */,
+				849E0AA325C96A6400B33506 /* OptionNodeFactoryTests.swift */,
+				849E0AA725C96AD600B33506 /* CompactNodeFactoryTests.swift */,
+				849E0AAB25C96C7800B33506 /* TupleNodeFactoryTests.swift */,
+				849E0AAF25C96DD500B33506 /* FixedArrayNodeFactoryTests.swift */,
+				849E0AB325C96EED00B33506 /* AliasNodeFactoryTests.swift */,
 			);
 			path = NodeFactory;
 			sourceTree = "<group>";
@@ -601,19 +619,23 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				849E0AB425C96EED00B33506 /* AliasNodeFactoryTests.swift in Sources */,
 				84DA3B4424C8CE5A00B5E27F /* ScaleInt16Tests.swift in Sources */,
+				849E0AA025C9684800B33506 /* VectorNodeFactoryTests.swift in Sources */,
 				84DA3B3E24C8CE5900B5E27F /* ScaleInt64Tests.swift in Sources */,
 				84DA3B4024C8CE5900B5E27F /* ScaleInt8Tests.swift in Sources */,
 				84DA3B4524C8CE5A00B5E27F /* ScaleUInt8Tests.swift in Sources */,
 				84DA3B3D24C8CE5900B5E27F /* ScaleCompactIntTests.swift in Sources */,
 				849E0A7425C9458F00B33506 /* StructNodeFactoryTests.swift in Sources */,
 				849E0A2125C81DB500B33506 /* FixedArrayParserTests.swift in Sources */,
+				849E0AA825C96AD600B33506 /* CompactNodeFactoryTests.swift in Sources */,
 				84DA3B4324C8CE5A00B5E27F /* ScaleStringTests.swift in Sources */,
 				84DA3B4224C8CE5A00B5E27F /* ScaleUInt64Tests.swift in Sources */,
 				849E0A7A25C94E3F00B33506 /* EnumMappingFactoryTests.swift in Sources */,
 				842D1E6A24CF800400C30A7A /* JunctionFactoryTests.swift in Sources */,
 				8429C7FD25C432FF0086D7F6 /* TypeRegistryTests.swift in Sources */,
 				841D52EA25C6DDF800DFA15B /* JSONHelpers.swift in Sources */,
+				849E0AAC25C96C7800B33506 /* TupleNodeFactoryTests.swift in Sources */,
 				849E0A8225C95E2700B33506 /* NumericSetFactoryTests.swift in Sources */,
 				84DA3B4124C8CE5A00B5E27F /* ScaleInt32Tests.swift in Sources */,
 				8467FD2624E71A37005D486C /* IconGenerationTests.swift in Sources */,
@@ -625,6 +647,8 @@
 				84ED7256254A001A006102DF /* SubstrateQREncoderTests.swift in Sources */,
 				841D52B425C6BAE600DFA15B /* ComponentsParserTests.swift in Sources */,
 				842D1E7324CFF4EC00C30A7A /* KeypairDeriviationTests.swift in Sources */,
+				849E0AA425C96A6400B33506 /* OptionNodeFactoryTests.swift in Sources */,
+				849E0AB025C96DD500B33506 /* FixedArrayNodeFactoryTests.swift in Sources */,
 				841D531625C6F70500DFA15B /* TypeSetParserTests.swift in Sources */,
 				84CB472424DBE82C00837E11 /* KeystoreExtractorTests.swift in Sources */,
 				84F4A847254CAD73000CF0A3 /* KeystoreBuilderTests.swift in Sources */,

--- a/FearlessUtils/Classes/Runtime/Nodes/NumericSetNodeFactory.swift
+++ b/FearlessUtils/Classes/Runtime/Nodes/NumericSetNodeFactory.swift
@@ -1,9 +1,5 @@
 import Foundation
 
-enum NumericSetNodeFactoryError: Error {
-    case invalidBitMapping
-}
-
 class NumericSetNodeFactory: TypeNodeFactoryProtocol {
     let parser: TypeParser
 
@@ -20,20 +16,24 @@ class NumericSetNodeFactory: TypeNodeFactoryProtocol {
             return nil
         }
 
-        let itemTypeNode = mediator.register(typeName: itemTypeName, json: itemType)
-
-        let bitVector: [SetNode.Item] = try items.dropFirst().map { bitItem in
+        let bitVector: [SetNode.Item] = items.dropFirst().compactMap { bitItem in
             guard
                 let components = bitItem.arrayValue,
                 components.count == 2,
                 let name = components.first?.stringValue,
                 let value = components.last?.unsignedIntValue else {
-                throw NumericSetNodeFactoryError.invalidBitMapping
+                return nil
             }
 
             return SetNode.Item(name: name, value: value)
         }
 
-        return SetNode(typeName: typeName, bitVector: bitVector, itemType: itemTypeNode)
+        guard bitVector.count == items.count - 1 else {
+            return nil
+        }
+
+        let itemTypeNode = mediator.register(typeName: itemTypeName, json: itemType)
+
+        return SetNode(typeName: typeName, bitVector: Set(bitVector), itemType: itemTypeNode)
     }
 }

--- a/FearlessUtils/Classes/Runtime/Nodes/TypeNode.swift
+++ b/FearlessUtils/Classes/Runtime/Nodes/TypeNode.swift
@@ -49,16 +49,21 @@ public struct EnumValuesNode: Node {
 }
 
 public struct SetNode: Node {
-    public struct Item {
-        let name: String
-        let value: UInt64
+    public struct Item: Hashable, Equatable {
+        public let name: String
+        public let value: UInt64
+
+        public init(name: String, value: UInt64) {
+            self.name = name
+            self.value = value
+        }
     }
 
     public let typeName: String
-    public let bitVector: [Item]
+    public let bitVector: Set<Item>
     public let itemType: Node
 
-    init(typeName: String, bitVector: [Item], itemType: Node) {
+    init(typeName: String, bitVector: Set<Item>, itemType: Node) {
         self.typeName = typeName
         self.bitVector = bitVector
         self.itemType = itemType

--- a/FearlessUtils/Classes/Runtime/TypeRegistry.swift
+++ b/FearlessUtils/Classes/Runtime/TypeRegistry.swift
@@ -43,6 +43,8 @@ public class TypeRegistry {
         try parse(json: json)
     }
 
+    public func node(for key: String) -> Node? { graph[key] }
+
     private func parse(json: JSON) throws {
         guard let dict = json.dictValue else {
             throw TypeRegistryError.unexpectedJson

--- a/FearlessUtils/Classes/Runtime/TypeRegistry.swift
+++ b/FearlessUtils/Classes/Runtime/TypeRegistry.swift
@@ -34,16 +34,31 @@ protocol TypeRegistering {
 public class TypeRegistry {
     private var graph: [String: Node] = [:]
     private var nodeFactory: TypeNodeFactoryProtocol
+    private var typeResolver: TypeResolving
 
     public var registeredTypes: [Node] { graph.keys.compactMap { graph[$0] } }
 
-    init(json: JSON, nodeFactory: TypeNodeFactoryProtocol) throws {
+    init(json: JSON, nodeFactory: TypeNodeFactoryProtocol, typeResolver: TypeResolving) throws {
         self.nodeFactory = nodeFactory
+        self.typeResolver = typeResolver
 
         try parse(json: json)
+        resolveGenerics()
     }
 
-    public func node(for key: String) -> Node? { graph[key] }
+    public func node(for key: String) -> Node? {
+        if let node = graph[key] {
+            return node
+        }
+
+        if let resolvedKey = typeResolver.resolve(typeName: key, using: Set(graph.keys)) {
+            return graph[resolvedKey]
+        }
+
+        return nil
+    }
+
+    // MARK: Private
 
     private func parse(json: JSON) throws {
         guard let dict = json.dictValue else {
@@ -72,6 +87,19 @@ public class TypeRegistry {
             }
         }
     }
+
+    private func resolveGenerics() {
+        let allTypeNames = Set(graph.keys)
+
+        let genericTypeNames = allTypeNames.filter { graph[$0] is GenericNode }
+
+        for genericTypeName in genericTypeNames {
+            if let resolvedKey = typeResolver.resolve(typeName: genericTypeName,
+                                                      using: allTypeNames.subtracting([genericTypeName])) {
+                graph[genericTypeName] = ProxyNode(typeName: resolvedKey, resolver: self)
+            }
+        }
+    }
 }
 
 public extension TypeRegistry {
@@ -96,8 +124,13 @@ public extension TypeRegistry {
             AliasNodeFactory(parser: TermParser.generic())
         ]
 
+        let resolvers: [TypeResolving] = [
+            CaseInsensitiveResolver()
+        ]
+
         return try TypeRegistry(json: types,
-                                nodeFactory: OneOfTypeNodeFactory(children: factories))
+                                nodeFactory: OneOfTypeNodeFactory(children: factories),
+                                typeResolver: OneOfTypeResolver(children: resolvers))
     }
 }
 

--- a/FearlessUtils/Classes/Runtime/TypeResolution/CaseInsensitiveResolver.swift
+++ b/FearlessUtils/Classes/Runtime/TypeResolution/CaseInsensitiveResolver.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+public class CaseInsensitiveResolver: TypeResolving {
+    public init() {}
+
+    public func resolve(typeName: String, using availableNames: Set<String>) -> String? {
+        availableNames.first { $0.caseInsensitiveCompare(typeName) == .orderedSame }
+    }
+}

--- a/FearlessUtils/Classes/Runtime/TypeResolution/OneOfTypeResolver.swift
+++ b/FearlessUtils/Classes/Runtime/TypeResolution/OneOfTypeResolver.swift
@@ -1,0 +1,19 @@
+import Foundation
+
+public class OneOfTypeResolver: TypeResolving {
+    public let children: [TypeResolving]
+
+    public init(children: [TypeResolving]) {
+        self.children = children
+    }
+
+    public func resolve(typeName: String, using availableNames: Set<String>) -> String? {
+        for child in children {
+            if let resolvedTypeName = child.resolve(typeName: typeName, using: availableNames) {
+                return resolvedTypeName
+            }
+        }
+
+        return nil
+    }
+}

--- a/FearlessUtils/Classes/Runtime/TypeResolution/TypeResolving.swift
+++ b/FearlessUtils/Classes/Runtime/TypeResolution/TypeResolving.swift
@@ -1,0 +1,5 @@
+import Foundation
+
+public protocol TypeResolving {
+    func resolve(typeName: String, using availableNames: Set<String>) -> String?
+}

--- a/Tests/Runtime/NodeFactory/AliasNodeFactoryTests.swift
+++ b/Tests/Runtime/NodeFactory/AliasNodeFactoryTests.swift
@@ -1,0 +1,49 @@
+import XCTest
+import FearlessUtils
+
+class AliasNodeFactoryTests: XCTestCase {
+    func testValidAliasFactory() throws {
+        // given
+
+        let typeName = "IdentityFields"
+        let subtypeName = "AccountInfo<Index>"
+        let recursiveName = "OptionCall"
+
+        let json = "{\"types\":{\"\(typeName)\": \"\(subtypeName)\", \"\(recursiveName)\": \"\(recursiveName)\"}}"
+
+        let data = json.data(using: .utf8)!
+
+        // when
+
+        let registry = try TypeRegistry.createFromTypesDefinition(data: data)
+
+        // then
+
+        XCTAssertNotNil(registry.node(for: typeName))
+        XCTAssertNotNil(registry.node(for: subtypeName))
+        XCTAssertNotNil(registry.node(for: recursiveName))
+    }
+
+    func testInvalidAliasFactory() throws {
+        let json1 = "{\"types\":{\"IdentityFields\": 2}}"
+
+        let json2 = "{\"types\":{\"IdentityFields\": [2, 3]}}"
+
+        let json3 = "{\"types\":{\"IdentityFields\": {\"Type\": \"Value\"}}}"
+
+        let type = "IdentityFields"
+
+        for json in [json1, json2, json3] {
+            let data = json.data(using: .utf8)!
+
+            let registry = try TypeRegistry.createFromTypesDefinition(data: data)
+
+            guard let node = registry.node(for: type) else {
+                XCTFail("Unexpected empty node")
+                return
+            }
+
+            XCTAssertTrue(node is GenericNode)
+        }
+    }
+}

--- a/Tests/Runtime/NodeFactory/CompactNodeFactoryTests.swift
+++ b/Tests/Runtime/NodeFactory/CompactNodeFactoryTests.swift
@@ -1,0 +1,53 @@
+import XCTest
+import FearlessUtils
+
+class CompactNodeFactoryTests: XCTestCase {
+    func testValidCompactFactory() throws {
+        // given
+
+        let typeName = "IdentityFields"
+        let subtypeName = "AccountInfo"
+
+        let json = "{\"types\":{\"\(typeName)\": \"Compact<\(subtypeName)>\"}}"
+
+        let data = json.data(using: .utf8)!
+
+        // when
+
+        let registry = try TypeRegistry.createFromTypesDefinition(data: data)
+
+        // then
+
+        guard let node = registry.node(for: typeName) as? CompactNode else {
+            XCTFail("Unexpected empty node")
+            return
+        }
+
+        XCTAssertEqual(typeName, node.typeName)
+        XCTAssertEqual(subtypeName, node.underlying.typeName)
+        XCTAssertNotNil(registry.node(for: subtypeName))
+    }
+
+    func testInvalidCompactFactory() throws {
+        let json1 = "{\"types\":{\"IdentityFields\": \"Compat<AccountInfo>\"}}"
+
+        let json2 = "{\"types\":{\"IdentityFields\": \"CompactAccountInfo>\"}}"
+
+        let json3 = "{\"types\":{\"IdentityFields\": \"Vec<AccountInfo>\"}}"
+
+        let type = "IdentityFields"
+
+        for json in [json1, json2, json3] {
+            let data = json.data(using: .utf8)!
+
+            let registry = try TypeRegistry.createFromTypesDefinition(data: data)
+
+            guard let vectorNode = registry.node(for: type) else {
+                XCTFail("Unexpected empty node")
+                return
+            }
+
+            XCTAssertFalse(vectorNode is CompactNode)
+        }
+    }
+}

--- a/Tests/Runtime/NodeFactory/EnumMappingFactoryTests.swift
+++ b/Tests/Runtime/NodeFactory/EnumMappingFactoryTests.swift
@@ -1,0 +1,55 @@
+import XCTest
+import FearlessUtils
+
+class EnumMappingFactoryTests: XCTestCase {
+
+    func testValidEnum() throws {
+        // given
+
+        let typeName = "Payment"
+        let expectedSubtypes = ["Weight", "DispatchClass", "Pays"]
+        let expectedFields = ["weight", "class", "paysFee"]
+
+        let json = "{\"types\": {\"Payment\": {\"type\":\"enum\",\"type_mapping\":[[\"weight\",\"Weight\"],[\"class\",\"DispatchClass\"],[\"paysFee\",\"Pays\"]]}}}"
+
+        let data = json.data(using: .utf8)!
+
+        let registry = try TypeRegistry.createFromTypesDefinition(data: data)
+
+        guard let enumNode = registry.node(for: typeName) as? EnumNode else {
+            XCTFail("Unexpected empty node")
+            return
+        }
+
+        XCTAssertEqual(enumNode.typeName, typeName)
+
+        let resultFields = enumNode.typeMapping.map { $0.name }
+        let resultSubtypes = enumNode.typeMapping.map { $0.node.typeName }
+
+        XCTAssertEqual(expectedFields, resultFields)
+        XCTAssertEqual(expectedSubtypes, resultSubtypes)
+    }
+
+    func testInvalidEnumResultsIntoGenericNode() throws {
+        let json1 = "{\"types\": {\"Payment\": {\"type\":\"enu\",\"type_mapping\":[[\"weight\",\"Weight\"],[\"class\",\"DispatchClass\"],[\"paysFee\",\"Pays\"]]}}}"
+
+        let json2 = "{\"types\": {\"Payment\": {\"type\":\"enum\",\"type_mappin\":[[\"weight\",\"Weight\"],[\"class\",\"DispatchClass\"],[\"paysFee\",\"Pays\"]]}}}"
+
+        let json3 = "{\"types\": {\"Payment\": {\"type\":\"enum\",\"type_mapping\":[[\"weight\"],[\"class\",\"DispatchClass\"],[\"paysFee\",\"Pays\"]]}}}"
+
+        let type = "Payment"
+
+        for json in [json1, json2, json3] {
+            let data = json.data(using: .utf8)!
+
+            let registry = try TypeRegistry.createFromTypesDefinition(data: data)
+
+            guard let node = registry.node(for: type) else {
+                XCTFail("Unexpected empty node")
+                return
+            }
+
+            XCTAssertTrue(node is GenericNode)
+        }
+    }
+}

--- a/Tests/Runtime/NodeFactory/EnumValuesFactoryTests.swift
+++ b/Tests/Runtime/NodeFactory/EnumValuesFactoryTests.swift
@@ -1,0 +1,49 @@
+import XCTest
+import FearlessUtils
+
+class EnumValuesFactoryTests: XCTestCase {
+    func testValidEnumValues() throws {
+        // given
+
+        let typeName = "Payment"
+        let expectedValues = ["weight", "class", "paysFee"]
+
+        let json = "{\"types\": {\"Payment\": {\"type\":\"enum\",\"value_list\":[\"weight\",\"class\",\"paysFee\"]}}}"
+
+        let data = json.data(using: .utf8)!
+
+        let registry = try TypeRegistry.createFromTypesDefinition(data: data)
+
+        guard let enumNode = registry.node(for: typeName) as? EnumValuesNode else {
+            XCTFail("Unexpected empty node")
+            return
+        }
+
+        XCTAssertEqual(enumNode.typeName, typeName)
+
+        XCTAssertEqual(expectedValues, enumNode.values)
+    }
+
+    func testInvalidEnumValuesResultsIntoGenericNode() throws {
+        let json1 = "{\"types\": {\"Payment\": {\"type\":\"enum\",\"vale_list\":[\"weight\",\"class\",\"paysFee\"]}}}"
+
+        let json2 = "{\"types\": {\"Payment\": {\"type\":\"enum\",\"value_list\": 2}}}"
+
+        let json3 = "{\"types\": {\"Payment\": {\"type\":\"enum\",\"value_list\":[2, 3]}}}"
+
+        let type = "Payment"
+
+        for json in [json1, json2, json3] {
+            let data = json.data(using: .utf8)!
+
+            let registry = try TypeRegistry.createFromTypesDefinition(data: data)
+
+            guard let node = registry.node(for: type) else {
+                XCTFail("Unexpected empty node")
+                return
+            }
+
+            XCTAssertTrue(node is GenericNode)
+        }
+    }
+}

--- a/Tests/Runtime/NodeFactory/FixedArrayNodeFactoryTests.swift
+++ b/Tests/Runtime/NodeFactory/FixedArrayNodeFactoryTests.swift
@@ -1,0 +1,55 @@
+import XCTest
+import FearlessUtils
+
+class FixedArrayNodeFactoryTests: XCTestCase {
+    func testValidFixedArrayFactory() throws {
+        // given
+
+        let typeName = "IdentityFields"
+        let subtypeName = "AccountInfo"
+        let length: UInt64 = 32
+
+        let json = "{\"types\":{\"\(typeName)\": \"[\(subtypeName); \(length)]\"}}"
+
+        let data = json.data(using: .utf8)!
+
+        // when
+
+        let registry = try TypeRegistry.createFromTypesDefinition(data: data)
+
+        // then
+
+        guard let node = registry.node(for: typeName) as? FixedArrayNode else {
+            XCTFail("Unexpected empty node")
+            return
+        }
+
+        XCTAssertEqual(typeName, node.typeName)
+        XCTAssertEqual(subtypeName, node.elementType.typeName)
+        XCTAssertEqual(length, node.length)
+        XCTAssertNotNil(registry.node(for: subtypeName))
+    }
+
+    func testInvalidFixedArrayFactory() throws {
+        let json1 = "{\"types\":{\"IdentityFields\": \"[AccountInfo; 32\"}}"
+
+        let json2 = "{\"types\":{\"IdentityFields\": \"VecAccountInfo>\"}}"
+
+        let json3 = "{\"types\":{\"IdentityFields\": \"(AccountInfo, 32)\"}}"
+
+        let type = "IdentityFields"
+
+        for json in [json1, json2, json3] {
+            let data = json.data(using: .utf8)!
+
+            let registry = try TypeRegistry.createFromTypesDefinition(data: data)
+
+            guard let node = registry.node(for: type) else {
+                XCTFail("Unexpected empty node")
+                return
+            }
+
+            XCTAssertFalse(node is FixedArrayNode)
+        }
+    }
+}

--- a/Tests/Runtime/NodeFactory/NumericSetFactoryTests.swift
+++ b/Tests/Runtime/NodeFactory/NumericSetFactoryTests.swift
@@ -1,0 +1,63 @@
+import XCTest
+import FearlessUtils
+
+class NumericSetFactoryTests: XCTestCase {
+    func testValidNumericSetFactory() throws {
+        // given
+
+        let typeName = "IdentityFields"
+        let itemTypeName = "u64"
+
+        let json = "{\"types\":{\"IdentityFields\":{\"type\":\"set\",\"value_type\":\"u64\",\"value_list\":{\"Display\":1,\"Legal\":2,\"Web\":4}}}}"
+
+        let expectedBitVector = [
+            SetNode.Item(name: "Display", value: 1),
+            SetNode.Item(name: "Legal", value: 2),
+            SetNode.Item(name: "Web", value: 4)
+        ]
+
+        let data = json.data(using: .utf8)!
+
+        // when
+
+        let registry = try TypeRegistry.createFromTypesDefinition(data: data)
+
+        // then
+
+        guard let setNode = registry.node(for: typeName) as? SetNode else {
+            XCTFail("Unexpected empty node")
+            return
+        }
+
+        XCTAssertEqual(typeName, setNode.typeName)
+        XCTAssertEqual(expectedBitVector, setNode.bitVector.sorted(by: { $0.value < $1.value }))
+        XCTAssertEqual(itemTypeName, setNode.itemType.typeName)
+    }
+
+    func testInvalidSetValuesResultsIntoGenericNode() throws {
+        let json1 = "{\"types\":{\"IdentityFields\":{\"type\":\"se\",\"value_type\":\"u64\",\"value_list\":{\"Display\":1,\"Legal\":2,\"Web\":4}}}}"
+
+        let json2 = "{\"types\":{\"IdentityFields\":{\"type\":\"set\",\"value_typ\":\"u64\",\"value_list\":{\"Display\":1,\"Legal\":2,\"Web\":4}}}}"
+
+        let json3 = "{\"types\":{\"IdentityFields\":{\"type\":\"set\",\"value_type\":\"u64\",\"value_lis\":{\"Display\":1,\"Legal\":2,\"Web\":4}}}}"
+
+        let json4 = "{\"types\":{\"IdentityFields\":{\"type\":\"set\",\"value_type\":\"u64\",\"value_list\":{\"Display\":\"1\",\"Legal\":2,\"Web\":4}}}}"
+
+        let json5 = "{\"types\":{\"IdentityFields\":{\"type\":\"set\",\"value_type\":\"u64\",\"value_list\":[1,2,4]}}}"
+
+        let type = "IdentityFields"
+
+        for json in [json1, json2, json3, json4, json5] {
+            let data = json.data(using: .utf8)!
+
+            let registry = try TypeRegistry.createFromTypesDefinition(data: data)
+
+            guard let structNode = registry.node(for: type) else {
+                XCTFail("Unexpected empty node")
+                return
+            }
+
+            XCTAssertTrue(structNode is GenericNode)
+        }
+    }
+}

--- a/Tests/Runtime/NodeFactory/NumericSetFactoryTests.swift
+++ b/Tests/Runtime/NodeFactory/NumericSetFactoryTests.swift
@@ -32,6 +32,7 @@ class NumericSetFactoryTests: XCTestCase {
         XCTAssertEqual(typeName, setNode.typeName)
         XCTAssertEqual(expectedBitVector, setNode.bitVector.sorted(by: { $0.value < $1.value }))
         XCTAssertEqual(itemTypeName, setNode.itemType.typeName)
+        XCTAssertNotNil(registry.node(for: itemTypeName))
     }
 
     func testInvalidSetValuesResultsIntoGenericNode() throws {
@@ -52,12 +53,12 @@ class NumericSetFactoryTests: XCTestCase {
 
             let registry = try TypeRegistry.createFromTypesDefinition(data: data)
 
-            guard let structNode = registry.node(for: type) else {
+            guard let node = registry.node(for: type) else {
                 XCTFail("Unexpected empty node")
                 return
             }
 
-            XCTAssertTrue(structNode is GenericNode)
+            XCTAssertTrue(node is GenericNode)
         }
     }
 }

--- a/Tests/Runtime/NodeFactory/OptionNodeFactoryTests.swift
+++ b/Tests/Runtime/NodeFactory/OptionNodeFactoryTests.swift
@@ -1,0 +1,53 @@
+import XCTest
+import FearlessUtils
+
+class OptionNodeFactoryTests: XCTestCase {
+    func testValidOptionFactory() throws {
+        // given
+
+        let typeName = "IdentityFields"
+        let subtypeName = "AccountInfo"
+
+        let json = "{\"types\":{\"\(typeName)\": \"Option<\(subtypeName)>\"}}"
+
+        let data = json.data(using: .utf8)!
+
+        // when
+
+        let registry = try TypeRegistry.createFromTypesDefinition(data: data)
+
+        // then
+
+        guard let node = registry.node(for: typeName) as? OptionNode else {
+            XCTFail("Unexpected empty node")
+            return
+        }
+
+        XCTAssertEqual(typeName, node.typeName)
+        XCTAssertEqual(subtypeName, node.underlying.typeName)
+        XCTAssertNotNil(registry.node(for: subtypeName))
+    }
+
+    func testInvalidOptionFactory() throws {
+        let json1 = "{\"types\":{\"IdentityFields\": \"Opton<AccountInfo>\"}}"
+
+        let json2 = "{\"types\":{\"IdentityFields\": \"OptionAccountInfo>\"}}"
+
+        let json3 = "{\"types\":{\"IdentityFields\": \"Vec<AccountInfo>\"}}"
+
+        let type = "IdentityFields"
+
+        for json in [json1, json2, json3] {
+            let data = json.data(using: .utf8)!
+
+            let registry = try TypeRegistry.createFromTypesDefinition(data: data)
+
+            guard let vectorNode = registry.node(for: type) else {
+                XCTFail("Unexpected empty node")
+                return
+            }
+
+            XCTAssertFalse(vectorNode is OptionNode)
+        }
+    }
+}

--- a/Tests/Runtime/NodeFactory/StructNodeFactoryTests.swift
+++ b/Tests/Runtime/NodeFactory/StructNodeFactoryTests.swift
@@ -1,0 +1,54 @@
+import XCTest
+import FearlessUtils
+
+class StructNodeFactoryTests: XCTestCase {
+    func testValidStruct() throws {
+        // given
+
+        let typeName = "Payment"
+        let expectedSubtypes = ["Weight", "DispatchClass", "Pays"]
+        let expectedFields = ["weight", "class", "paysFee"]
+
+        let json = "{\"types\": {\"Payment\": {\"type\":\"struct\",\"type_mapping\":[[\"weight\",\"Weight\"],[\"class\",\"DispatchClass\"],[\"paysFee\",\"Pays\"]]}}}"
+
+        let data = json.data(using: .utf8)!
+
+        let registry = try TypeRegistry.createFromTypesDefinition(data: data)
+
+        guard let structNode = registry.node(for: typeName) as? StructNode else {
+            XCTFail("Unexpected empty node")
+            return
+        }
+
+        XCTAssertEqual(structNode.typeName, typeName)
+
+        let resultFields = structNode.typeMapping.map { $0.name }
+        let resultSubtypes = structNode.typeMapping.map { $0.node.typeName }
+
+        XCTAssertEqual(expectedFields, resultFields)
+        XCTAssertEqual(expectedSubtypes, resultSubtypes)
+    }
+
+    func testInvalidStructResultsIntoGenericNode() throws {
+        let json1 = "{\"types\": {\"Payment\": {\"type\":\"struc\",\"type_mapping\":[[\"weight\",\"Weight\"],[\"class\",\"DispatchClass\"],[\"paysFee\",\"Pays\"]]}}}"
+
+        let json2 = "{\"types\": {\"Payment\": {\"type\":\"struct\",\"type_mappin\":[[\"weight\",\"Weight\"],[\"class\",\"DispatchClass\"],[\"paysFee\",\"Pays\"]]}}}"
+
+        let json3 = "{\"types\": {\"Payment\": {\"type\":\"struct\",\"type_mapping\":[[\"weight\"],[\"class\",\"DispatchClass\"],[\"paysFee\",\"Pays\"]]}}}"
+
+        let type = "Payment"
+
+        for json in [json1, json2, json3] {
+            let data = json.data(using: .utf8)!
+
+            let registry = try TypeRegistry.createFromTypesDefinition(data: data)
+
+            guard let node = registry.node(for: type) else {
+                XCTFail("Unexpected empty node")
+                return
+            }
+
+            XCTAssertTrue(node is GenericNode)
+        }
+    }
+}

--- a/Tests/Runtime/NodeFactory/TupleNodeFactoryTests.swift
+++ b/Tests/Runtime/NodeFactory/TupleNodeFactoryTests.swift
@@ -1,0 +1,59 @@
+import XCTest
+import FearlessUtils
+
+class TupleNodeFactoryTests: XCTestCase {
+
+    func testValidTupleFactory() throws {
+        // given
+
+        let typeName = "IdentityFields"
+        let subtypeName1 = "AccountInfo"
+        let subtypeName2 = "AccountIndex<u64>"
+
+        let json = "{\"types\":{\"\(typeName)\": \"(\(subtypeName1), \(subtypeName2))\"}}"
+
+        let data = json.data(using: .utf8)!
+
+        // when
+
+        let registry = try TypeRegistry.createFromTypesDefinition(data: data)
+
+        // then
+
+        guard let tupleNode = registry.node(for: typeName) as? TupleNode else {
+            XCTFail("Unexpected empty node")
+            return
+        }
+
+        let subtypes = tupleNode.innerNodes.map { $0.typeName }
+
+        XCTAssertEqual(typeName, tupleNode.typeName)
+        XCTAssertEqual(subtypes, [subtypeName1, subtypeName2])
+        XCTAssertNotNil(registry.node(for: subtypeName1))
+        XCTAssertNotNil(registry.node(for: subtypeName2))
+    }
+
+    func testInvalidTupleFactory() throws {
+        let json1 = "{\"types\":{\"IdentityFields\": \"(AccountInfo, AccountIndex\"}}"
+
+        let json2 = "{\"types\":{\"IdentityFields\": \"VecAccountInfo>\"}}"
+
+        let json3 = "{\"types\":{\"IdentityFields\": \"(AccountInfo, AccountIndex,)\"}}"
+
+        let type = "IdentityFields"
+
+        for json in [json1, json2, json3] {
+            let data = json.data(using: .utf8)!
+
+            let registry = try TypeRegistry.createFromTypesDefinition(data: data)
+
+            guard let node = registry.node(for: type) else {
+                XCTFail("Unexpected empty node")
+                return
+            }
+
+            XCTAssertFalse(node is TupleNode)
+        }
+    }
+
+}

--- a/Tests/Runtime/NodeFactory/VectorNodeFactoryTests.swift
+++ b/Tests/Runtime/NodeFactory/VectorNodeFactoryTests.swift
@@ -1,0 +1,53 @@
+import XCTest
+import FearlessUtils
+
+class VectorNodeFactoryTests: XCTestCase {
+    func testValidVectorFactory() throws {
+        // given
+
+        let typeName = "IdentityFields"
+        let subtypeName = "AccountInfo"
+
+        let json = "{\"types\":{\"\(typeName)\": \"Vec<\(subtypeName)>\"}}"
+
+        let data = json.data(using: .utf8)!
+
+        // when
+
+        let registry = try TypeRegistry.createFromTypesDefinition(data: data)
+
+        // then
+
+        guard let vectorNode = registry.node(for: typeName) as? VectorNode else {
+            XCTFail("Unexpected empty node")
+            return
+        }
+
+        XCTAssertEqual(typeName, vectorNode.typeName)
+        XCTAssertEqual(subtypeName, vectorNode.underlying.typeName)
+        XCTAssertNotNil(registry.node(for: subtypeName))
+    }
+
+    func testInvalidVectorFactory() throws {
+        let json1 = "{\"types\":{\"IdentityFields\": \"Ve<AccountInfo>\"}}"
+
+        let json2 = "{\"types\":{\"IdentityFields\": \"VecAccountInfo>\"}}"
+
+        let json3 = "{\"types\":{\"IdentityFields\": \"Option<AccountInfo>\"}}"
+
+        let type = "IdentityFields"
+
+        for json in [json1, json2, json3] {
+            let data = json.data(using: .utf8)!
+
+            let registry = try TypeRegistry.createFromTypesDefinition(data: data)
+
+            guard let vectorNode = registry.node(for: type) else {
+                XCTFail("Unexpected empty node")
+                return
+            }
+
+            XCTAssertFalse(vectorNode is VectorNode)
+        }
+    }
+}

--- a/Tests/Runtime/TypeRegistryTests.swift
+++ b/Tests/Runtime/TypeRegistryTests.swift
@@ -17,4 +17,26 @@ class TypeRegistryTests: XCTestCase {
             XCTFail("Unexpected error \(error)")
         }
     }
+
+    func testCaseInsensitiveResolutionApplied() throws {
+        // given
+
+        let typeName = "IdentityFields"
+        let subtypeName = "AccountInfo<Index>"
+        let recursiveName = "OptionCall"
+
+        let searchingTypeName = "Accountinfo<Index>"
+
+        let json = "{\"types\":{\"\(typeName)\": \"\(subtypeName)\", \"\(recursiveName)\": \"\(recursiveName)\"}}"
+
+        let data = json.data(using: .utf8)!
+
+        // when
+
+        let registry = try TypeRegistry.createFromTypesDefinition(data: data)
+
+        // then
+
+        XCTAssertNotNil(registry.node(for: searchingTypeName))
+    }
 }

--- a/Tests/Runtime/TypeResolution/CaseInsensitiveResolverTests.swift
+++ b/Tests/Runtime/TypeResolution/CaseInsensitiveResolverTests.swift
@@ -1,0 +1,35 @@
+import XCTest
+import FearlessUtils
+
+class CaseInsensitiveResolverTests: XCTestCase {
+    func testCaseInsensitiveSuccessResolution() {
+        // given
+
+        let resolver = CaseInsensitiveResolver()
+        let searchingType = "Bidkind<Type>"
+        let expectedType = "BidKind<Type>"
+
+        // when
+
+        let result = resolver.resolve(typeName: searchingType, using: ["Type1", "Type2", expectedType])
+
+        // then
+
+        XCTAssertEqual(expectedType, result)
+    }
+
+    func testCaseInsensitiveUnsucessResolution() {
+        // given
+
+        let resolver = CaseInsensitiveResolver()
+        let searchingType = "Bidkind<Type>"
+
+        // when
+
+        let result = resolver.resolve(typeName: searchingType, using: ["Type1", "Type2", "BidKind"])
+
+        // then
+
+        XCTAssertNil(result)
+    }
+}


### PR DESCRIPTION
- add key resolver definition and case insensitive key resolver: the idea is to allow certain type names to map to others, for example one can allow case insensitive search by type name
- add tests for graph node factories