### PR TITLE
Type parsing optimization

### DIFF
--- a/FearlessUtils/Classes/Runtime/Nodes/Items/AccountIdAddressNode.swift
+++ b/FearlessUtils/Classes/Runtime/Nodes/Items/AccountIdAddressNode.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public struct AccountIdAddressNode: Node {
+public class AccountIdAddressNode: Node {
     public var typeName: String { "AccountIdAddress" }
 
     public init() {}

--- a/FearlessUtils/Classes/Runtime/Nodes/Items/BasicNode.swift
+++ b/FearlessUtils/Classes/Runtime/Nodes/Items/BasicNode.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public struct U8Node: Node {
+public class U8Node: Node {
     public var typeName: String { PrimitiveType.u8.name }
 
     public init() {}
@@ -14,7 +14,7 @@ public struct U8Node: Node {
     }
 }
 
-public struct U16Node: Node {
+public class U16Node: Node {
     public var typeName: String { PrimitiveType.u16.name }
 
     public init() {}
@@ -28,7 +28,7 @@ public struct U16Node: Node {
     }
 }
 
-public struct U32Node: Node {
+public class U32Node: Node {
     public var typeName: String { PrimitiveType.u32.name }
 
     public init() {}
@@ -42,7 +42,7 @@ public struct U32Node: Node {
     }
 }
 
-public struct U64Node: Node {
+public class U64Node: Node {
     public var typeName: String { PrimitiveType.u64.name }
 
     public init() {}
@@ -56,7 +56,7 @@ public struct U64Node: Node {
     }
 }
 
-public struct U128Node: Node {
+public class U128Node: Node {
     public var typeName: String { PrimitiveType.u128.name }
 
     public init() {}
@@ -70,7 +70,7 @@ public struct U128Node: Node {
     }
 }
 
-public struct U256Node: Node {
+public class U256Node: Node {
     public var typeName: String { PrimitiveType.u256.name }
 
     public init() {}
@@ -84,7 +84,7 @@ public struct U256Node: Node {
     }
 }
 
-public struct BoolNode: Node {
+public class BoolNode: Node {
     public var typeName: String { PrimitiveType.bool.name }
 
     public init() {}
@@ -98,7 +98,7 @@ public struct BoolNode: Node {
     }
 }
 
-public struct StringNode: Node {
+public class StringNode: Node {
     public var typeName: String { PrimitiveType.string.name }
 
     public init() {}

--- a/FearlessUtils/Classes/Runtime/Nodes/Items/BitVecNode.swift
+++ b/FearlessUtils/Classes/Runtime/Nodes/Items/BitVecNode.swift
@@ -7,7 +7,7 @@ public enum BitVecNodeError: Error {
     case expectedHex
 }
 
-public struct BitVecNode: Node {
+public class BitVecNode: Node {
     public var typeName: String { GenericType.bitVec.name }
 
     public init() {}

--- a/FearlessUtils/Classes/Runtime/Nodes/Items/BoxProposalNode.swift
+++ b/FearlessUtils/Classes/Runtime/Nodes/Items/BoxProposalNode.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public struct BoxProposalNode: Node {
+public class BoxProposalNode: Node {
     public var typeName: String { GenericType.boxProposal.name }
     public let runtimeMetadata: RuntimeMetadata
 

--- a/FearlessUtils/Classes/Runtime/Nodes/Items/BytesNode.swift
+++ b/FearlessUtils/Classes/Runtime/Nodes/Items/BytesNode.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public struct BytesNode: Node {
+public class BytesNode: Node {
     public var typeName: String { GenericType.bytes.name }
 
     public init() {}

--- a/FearlessUtils/Classes/Runtime/Nodes/Items/CallBytesNode.swift
+++ b/FearlessUtils/Classes/Runtime/Nodes/Items/CallBytesNode.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public struct CallBytesNode: Node {
+public class CallBytesNode: Node {
     public var typeName: String { GenericType.callBytes.name }
 
     public init() {}

--- a/FearlessUtils/Classes/Runtime/Nodes/Items/CompactNode.swift
+++ b/FearlessUtils/Classes/Runtime/Nodes/Items/CompactNode.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public struct CompactNode: Node {
+public class CompactNode: Node {
     public let typeName: String
     public let underlying: Node
 

--- a/FearlessUtils/Classes/Runtime/Nodes/Items/DataNode.swift
+++ b/FearlessUtils/Classes/Runtime/Nodes/Items/DataNode.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public struct DataNode: Node {
+public class DataNode: Node {
     public var typeName: String { GenericType.data.name }
 
     public init() {}

--- a/FearlessUtils/Classes/Runtime/Nodes/Items/EcdsaNode.swift
+++ b/FearlessUtils/Classes/Runtime/Nodes/Items/EcdsaNode.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public struct EcdsaNode: Node {
+public class EcdsaNode: Node {
     public var typeName: String { GenericType.ecdsa.name }
 
     public init() {}

--- a/FearlessUtils/Classes/Runtime/Nodes/Items/EnumNode.swift
+++ b/FearlessUtils/Classes/Runtime/Nodes/Items/EnumNode.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public struct EnumNode: Node {
+public class EnumNode: Node {
     public let typeName: String
     public let typeMapping: [NameNode]
 

--- a/FearlessUtils/Classes/Runtime/Nodes/Items/EnumValuesNode.swift
+++ b/FearlessUtils/Classes/Runtime/Nodes/Items/EnumValuesNode.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public struct EnumValuesNode: Node {
+public class EnumValuesNode: Node {
     public let typeName: String
     public let values: [String]
 

--- a/FearlessUtils/Classes/Runtime/Nodes/Items/EraNode.swift
+++ b/FearlessUtils/Classes/Runtime/Nodes/Items/EraNode.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public struct EraNode: Node {
+public class EraNode: Node {
     public var typeName: String { GenericType.era.name }
 
     public init() {}

--- a/FearlessUtils/Classes/Runtime/Nodes/Items/EventRecordNode.swift
+++ b/FearlessUtils/Classes/Runtime/Nodes/Items/EventRecordNode.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public struct EventRecordNode: Node {
+public class EventRecordNode: Node {
     public var typeName: String { GenericType.eventRecord.name }
     public let runtimeMetadata: RuntimeMetadata
 

--- a/FearlessUtils/Classes/Runtime/Nodes/Items/ExtrinsicExtraNode.swift
+++ b/FearlessUtils/Classes/Runtime/Nodes/Items/ExtrinsicExtraNode.swift
@@ -5,7 +5,7 @@ public enum ExtrinsicExtraNodeError: Error {
     case unsupportedExtension(_ value: String)
 }
 
-public struct ExtrinsicExtraNode: Node {
+public class ExtrinsicExtraNode: Node {
     public var typeName: String { GenericType.extrinsicExtra.name }
     public let runtimeMetadata: RuntimeMetadata
 

--- a/FearlessUtils/Classes/Runtime/Nodes/Items/ExtrinsicNode.swift
+++ b/FearlessUtils/Classes/Runtime/Nodes/Items/ExtrinsicNode.swift
@@ -6,7 +6,7 @@ public enum ExtrinsicNodeError: Error {
     case invalidVersion
 }
 
-public struct ExtrinsicNode: Node {
+public class ExtrinsicNode: Node {
     public var typeName: String { GenericType.extrinsic.name }
 
     public init() {}

--- a/FearlessUtils/Classes/Runtime/Nodes/Items/ExtrinsicSignatureNode.swift
+++ b/FearlessUtils/Classes/Runtime/Nodes/Items/ExtrinsicSignatureNode.swift
@@ -4,7 +4,7 @@ public enum ExtrinsicSignatureNodeError: Error {
     case invalidParams
 }
 
-public struct ExtrinsicSignatureNode: Node {
+public class ExtrinsicSignatureNode: Node {
     public var typeName: String { GenericType.extrinsicSignature.name }
     public let runtimeMetadata: RuntimeMetadata
 

--- a/FearlessUtils/Classes/Runtime/Nodes/Items/ExtrinsicsDecoderNode.swift
+++ b/FearlessUtils/Classes/Runtime/Nodes/Items/ExtrinsicsDecoderNode.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public struct ExtrinsicsDecoderNode: Node {
+public class ExtrinsicsDecoderNode: Node {
     public var typeName: String { GenericType.extrinsicDecoder.name }
 
     public init() {}

--- a/FearlessUtils/Classes/Runtime/Nodes/Items/FixedArrayNode.swift
+++ b/FearlessUtils/Classes/Runtime/Nodes/Items/FixedArrayNode.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public struct FixedArrayNode: Node {
+public class FixedArrayNode: Node {
     public let typeName: String
     public let elementType: Node
     public let length: UInt64

--- a/FearlessUtils/Classes/Runtime/Nodes/Items/GenericAccountId.swift
+++ b/FearlessUtils/Classes/Runtime/Nodes/Items/GenericAccountId.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public struct GenericAccountIdNode: Node {
+public class GenericAccountIdNode: Node {
     public var typeName: String { GenericType.accountId.name }
 
     public init() {}

--- a/FearlessUtils/Classes/Runtime/Nodes/Items/GenericAccountIndexNode.swift
+++ b/FearlessUtils/Classes/Runtime/Nodes/Items/GenericAccountIndexNode.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public struct GenericAccountIndexNode: Node {
+public class GenericAccountIndexNode: Node {
     public var typeName: String { GenericType.accountIndex.name }
 
     public init() {}

--- a/FearlessUtils/Classes/Runtime/Nodes/Items/GenericBlockNode.swift
+++ b/FearlessUtils/Classes/Runtime/Nodes/Items/GenericBlockNode.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public struct GenericBlockNode: Node {
+public class GenericBlockNode: Node {
     public var typeName: String { GenericType.block.name }
 
     public init() {}

--- a/FearlessUtils/Classes/Runtime/Nodes/Items/GenericCallNode.swift
+++ b/FearlessUtils/Classes/Runtime/Nodes/Items/GenericCallNode.swift
@@ -9,7 +9,7 @@ public enum GenericCallNodeError: Error {
     case unexpectedDecodedFunction
 }
 
-public struct GenericCallNode: Node {
+public class GenericCallNode: Node {
     public var typeName: String { GenericType.call.name }
     public let runtimeMetadata: RuntimeMetadata
 

--- a/FearlessUtils/Classes/Runtime/Nodes/Items/GenericConsensusEngineIdNode.swift
+++ b/FearlessUtils/Classes/Runtime/Nodes/Items/GenericConsensusEngineIdNode.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public struct GenericConsensusEngineIdNode: Node {
+public class GenericConsensusEngineIdNode: Node {
     public var typeName: String { GenericType.consensusEngineId.name }
 
     public init() {}

--- a/FearlessUtils/Classes/Runtime/Nodes/Items/GenericEventNode.swift
+++ b/FearlessUtils/Classes/Runtime/Nodes/Items/GenericEventNode.swift
@@ -9,7 +9,7 @@ public enum GenericEventNodeError: Error {
     case unexpectedDecodedEventIndex
 }
 
-public struct GenericEventNode: Node {
+public class GenericEventNode: Node {
     public var typeName: String { GenericType.event.name }
     public let runtimeMetadata: RuntimeMetadata
 

--- a/FearlessUtils/Classes/Runtime/Nodes/Items/GenericMultiAddressNode.swift
+++ b/FearlessUtils/Classes/Runtime/Nodes/Items/GenericMultiAddressNode.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public struct GenericMultiAddressNode: Node {
+public class GenericMultiAddressNode: Node {
     public static let typeMapping = [
         [MultiAddress.accountIdField, GenericType.accountId.name],
         [MultiAddress.indexField, "Compact<\(GenericType.accountIndex.name)>"],

--- a/FearlessUtils/Classes/Runtime/Nodes/Items/GenericNode.swift
+++ b/FearlessUtils/Classes/Runtime/Nodes/Items/GenericNode.swift
@@ -1,7 +1,11 @@
 import Foundation
 
-public struct GenericNode: Node {
+public class GenericNode: Node {
     public let typeName: String
+
+    public init(typeName: String) {
+        self.typeName = typeName
+    }
 
     public func accept(encoder: DynamicScaleEncoding, value: JSON) throws {
         throw DynamicScaleCoderError.unresolverType(name: typeName)

--- a/FearlessUtils/Classes/Runtime/Nodes/Items/GenericVoteNode.swift
+++ b/FearlessUtils/Classes/Runtime/Nodes/Items/GenericVoteNode.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public struct GenericVoteNode: Node {
+public class GenericVoteNode: Node {
     public var typeName: String { GenericType.vote.name }
 
     public init() {}

--- a/FearlessUtils/Classes/Runtime/Nodes/Items/H160Node.swift
+++ b/FearlessUtils/Classes/Runtime/Nodes/Items/H160Node.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public struct H160Node: Node {
+public class H160Node: Node {
     public var typeName: String { GenericType.h160.name }
 
     public init() {}

--- a/FearlessUtils/Classes/Runtime/Nodes/Items/H256Node.swift
+++ b/FearlessUtils/Classes/Runtime/Nodes/Items/H256Node.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public struct H256Node: Node {
+public class H256Node: Node {
     public var typeName: String { GenericType.h256.name }
 
     public init() {}

--- a/FearlessUtils/Classes/Runtime/Nodes/Items/H512Node.swift
+++ b/FearlessUtils/Classes/Runtime/Nodes/Items/H512Node.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public struct H512Node: Node {
+public class H512Node: Node {
     public var typeName: String { GenericType.h512.name }
 
     public init() {}

--- a/FearlessUtils/Classes/Runtime/Nodes/Items/MappingNode.swift
+++ b/FearlessUtils/Classes/Runtime/Nodes/Items/MappingNode.swift
@@ -10,7 +10,7 @@ public struct NamedType {
     }
 }
 
-public struct MappingNode: Node {
+public class MappingNode: Node {
     public let typeName: String
     public let typeMapping: [NamedType]
 

--- a/FearlessUtils/Classes/Runtime/Nodes/Items/NullNode.swift
+++ b/FearlessUtils/Classes/Runtime/Nodes/Items/NullNode.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public struct NullNode: Node {
+public class NullNode: Node {
     public var typeName: String { GenericType.null.name }
 
     public init() {}

--- a/FearlessUtils/Classes/Runtime/Nodes/Items/OpaqueCall.swift
+++ b/FearlessUtils/Classes/Runtime/Nodes/Items/OpaqueCall.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public struct OpaqueCallNode: Node {
+public class OpaqueCallNode: Node {
     public var typeName: String { GenericType.opaqueCall.name }
     public let runtimeMetadata: RuntimeMetadata
 

--- a/FearlessUtils/Classes/Runtime/Nodes/Items/OptionNode.swift
+++ b/FearlessUtils/Classes/Runtime/Nodes/Items/OptionNode.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public struct OptionNode: Node {
+public class OptionNode: Node {
     public let typeName: String
     public let underlying: Node
 

--- a/FearlessUtils/Classes/Runtime/Nodes/Items/ProxyNode.swift
+++ b/FearlessUtils/Classes/Runtime/Nodes/Items/ProxyNode.swift
@@ -4,7 +4,7 @@ public protocol NodeResolver: class {
     func resolve(for key: String) -> Node?
 }
 
-public struct ProxyNode: Node {
+public class ProxyNode: Node {
     public let typeName: String
     public weak var resolver: NodeResolver?
 

--- a/FearlessUtils/Classes/Runtime/Nodes/Items/SessionKeysSubstrateNode.swift
+++ b/FearlessUtils/Classes/Runtime/Nodes/Items/SessionKeysSubstrateNode.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public struct SessionKeysSubstrateNode: Node {
+public class SessionKeysSubstrateNode: Node {
     static let fieldNames: [String] = ["grandpa", "babe", "im_online"]
     static let fieldTypeName: String = GenericType.accountId.name
 

--- a/FearlessUtils/Classes/Runtime/Nodes/Items/SetNode.swift
+++ b/FearlessUtils/Classes/Runtime/Nodes/Items/SetNode.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public struct SetNode: Node {
+public class SetNode: Node {
     public struct Item: Hashable, Equatable {
         public let name: String
         public let value: UInt64

--- a/FearlessUtils/Classes/Runtime/Nodes/Items/StructNode.swift
+++ b/FearlessUtils/Classes/Runtime/Nodes/Items/StructNode.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public struct StructNode: Node {
+public class StructNode: Node {
     public let typeName: String
     public let typeMapping: [NameNode]
 

--- a/FearlessUtils/Classes/Runtime/Nodes/Items/TupleNode.swift
+++ b/FearlessUtils/Classes/Runtime/Nodes/Items/TupleNode.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public struct TupleNode: Node {
+public class TupleNode: Node {
     public let typeName: String
     public let innerNodes: [Node]
 

--- a/FearlessUtils/Classes/Runtime/Nodes/Items/TypeNode.swift
+++ b/FearlessUtils/Classes/Runtime/Nodes/Items/TypeNode.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public protocol Node: DynamicScaleCodable {
+public protocol Node: class, DynamicScaleCodable {
     var typeName: String { get }
 }
 

--- a/FearlessUtils/Classes/Runtime/Nodes/Items/VectorNode.swift
+++ b/FearlessUtils/Classes/Runtime/Nodes/Items/VectorNode.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public struct VectorNode: Node {
+public class VectorNode: Node {
     public let typeName: String
     public let underlying: Node
 


### PR DESCRIPTION
- move type registry nodes from struct to classes to reduce copying during type search
- optimize type resolution for registry
- optimize registry resolution for type and version pair