### PR TITLE
Signed extensions processing

### DIFF
--- a/FearlessUtils/Classes/Extrinsic/ExtrinsicBuilder.swift
+++ b/FearlessUtils/Classes/Extrinsic/ExtrinsicBuilder.swift
@@ -87,7 +87,7 @@ public final class ExtrinsicBuilder {
                                         metadata: RuntimeMetadata) throws {
         for checkString in metadata.extrinsic.signedExtensions {
             guard let check = ExtrinsicCheck(rawValue: checkString) else {
-                throw ExtrinsicBuilderError.unsupportedSignedExtension(checkString)
+                continue
             }
 
             switch check {

--- a/FearlessUtils/Classes/Runtime/Nodes/Items/ExtrinsicExtraNode.swift
+++ b/FearlessUtils/Classes/Runtime/Nodes/Items/ExtrinsicExtraNode.swift
@@ -2,7 +2,6 @@ import Foundation
 
 public enum ExtrinsicExtraNodeError: Error {
     case invalidParams
-    case unsupportedExtension(_ value: String)
 }
 
 public class ExtrinsicExtraNode: Node {
@@ -20,7 +19,7 @@ public class ExtrinsicExtraNode: Node {
 
         for checkString in runtimeMetadata.extrinsic.signedExtensions {
             guard let check = ExtrinsicCheck(rawValue: checkString) else {
-                throw ExtrinsicExtraNodeError.unsupportedExtension(checkString)
+                continue
             }
 
             switch check {

--- a/Tests/ExtrinsicBuilder/ExtrinsicBuilderTests.swift
+++ b/Tests/ExtrinsicBuilder/ExtrinsicBuilderTests.swift
@@ -98,51 +98,6 @@ class ExtrinsicBuilderTests: XCTestCase {
         }
     }
 
-    func testUnknownSignedExtensionsNotIgnored() {
-        let unsupportedExtension = "UnknownExtension"
-        let genesisHash = Data(repeating: 0, count: 32).toHex(includePrefix: true)
-        let specVersion: UInt32 = 28
-
-        do {
-            let account = Data(repeating: 1, count: 32)
-
-            let args = TransferArgs(dest: .accoundId(account), value: 1)
-            let call = RuntimeCall(moduleName: "Balances",
-                                   callName: "transfer",
-                                   args: args)
-
-            let closure: ExtrinsicBuilderClosure = { builder in
-                return try builder.adding(call: call)
-            }
-
-            let prevMetadata = try RuntimeHelper.createRuntimeMetadata("polkadot-metadata")
-
-            let newExtensions = prevMetadata.extrinsic.signedExtensions + [unsupportedExtension]
-            let metadata = RuntimeMetadata(metaReserved: prevMetadata.metaReserved,
-                                           runtimeMetadataVersion: prevMetadata.runtimeMetadataVersion,
-                                           modules: prevMetadata.modules,
-                                           extrinsic: ExtrinsicMetadata(version: prevMetadata.extrinsic.version,
-                                                                        signedExtensions: newExtensions))
-
-            try setupSignedExtrinsicBuilderTest("default",
-                                                networkName: "polkadot",
-                                                metadata: metadata,
-                                                cryptoType: .sr25519,
-                                                genesisHash: genesisHash,
-                                                specVersion: specVersion,
-                                                builderClosure: closure,
-                                                expectedCall: nil)
-        } catch {
-            if
-                let error = error as? ExtrinsicExtraNodeError,
-                case .unsupportedExtension(let value) = error {
-                XCTAssertEqual(unsupportedExtension, value)
-            } else {
-                XCTFail("Unexpected error: \(error)")
-            }
-        }
-    }
-
     // MARK: Private
 
     private func performExtrinsicWithSingleCall(for cryptoType: CryptoType) {


### PR DESCRIPTION
- ignore unknown signed extensions instead of throwing error